### PR TITLE
posture editor: improve shadows

### DIFF
--- a/posture-editor.html
+++ b/posture-editor.html
@@ -34,8 +34,9 @@
 			// create a scene with a better shadow
 			createScene();
 			var light = scene.children[0];
-				light.shadow.mapSize.width = 4*1024;
-				light.shadow.mapSize.height = 4*1024;
+				light.shadow.mapSize.width = 2*1024;
+				light.shadow.mapSize.height = 2*1024;
+				light.shadow.radius = 2;
 
 			var controls = new THREE.OrbitControls( camera, renderer.domElement );
 


### PR DESCRIPTION
In the posture editor, there is a warning on Firefox: `THREE.WebGLShadowMap has shadow exceeding max texture size, reducing` due to the high resolution of the model shadow.

This PR remove this warning by reducing shadow resolution (and add a small blur to avoid pixelated shadow). It also improve performance and shadow aspect on Firefox.

Actual shadow on Firefox:
![Screenshot_20210411_021056](https://user-images.githubusercontent.com/1665542/114442484-e1de2d80-9bcc-11eb-84ad-aef537876792.png)

Actual shadow on Chrome:
![Screenshot_20210411_024143](https://user-images.githubusercontent.com/1665542/114442496-e3a7f100-9bcc-11eb-8718-bb74cce33d9d.png)

New shadow on Firefox and Chrome:
![Screenshot_20210411_021642](https://user-images.githubusercontent.com/1665542/114442495-e30f5a80-9bcc-11eb-9102-3614507576a5.png)
