### PR TITLE
Added 2 methods to the Joint class:

### DIFF
--- a/mannequin.js
+++ b/mannequin.js
@@ -431,12 +431,28 @@ class Joint extends THREE.Group
 		this.image.visible = false;
 	} // Joint.hide
 
+	show()
+	{
+		this.image.visible = true;
+	} // Joint.show
+	
 	// attach Object3D instance to the joint
 	attach(image)
 	{
 		this.imageWrapper.add(image);
 	} // Joint.attach
 
+	detach(image)
+	{
+		if (this.imageWrapper.children.includes(
+			this.imageWrapper.getObjectById(image.id)) )
+		{
+			this.imageWrapper.remove(
+				this.imageWrapper.getObjectById(image.id)
+			);
+		}
+	} // Joint.detach
+	
 	// calculate global coordinates of point with coordinates relative to the joint
 	point(x, y, z)
 	{


### PR DESCRIPTION
**`.show()`** method sets the Joint class `image.visible` property true

**`.detach()`** method polls the children of Joint's `imageWrapper` THREE.Group property for a matching `.id` parameter from the passed `Object3D` type. If true, the method removes the previously attached child from the `imageWrapper` group.

Would you like me to:
- update the README to include these methods?
- create live examples for show/hide & attach/detach?